### PR TITLE
API for requesting comments from a specific article

### DIFF
--- a/lib/elixirplusreddit/api/authentication.ex
+++ b/lib/elixirplusreddit/api/authentication.ex
@@ -27,8 +27,8 @@ defmodule ElixirPlusReddit.API.Authentication do
   defp retry_until_success(endpoint, body, basic_auth) do
     {resp, strategy} = Request.request_token(@token_endpoint, body, basic_auth)
     case resp.status_code do
-      503 -> retry_until_success(endpoint, body, basic_auth)
-      _   -> Parser.parse(resp, strategy)
+      c when c in 500..599 -> retry_until_success(endpoint, body, basic_auth)
+      _ -> Parser.parse(resp, strategy)
     end
   end
 

--- a/lib/elixirplusreddit/api/comment.ex
+++ b/lib/elixirplusreddit/api/comment.ex
@@ -1,0 +1,101 @@
+defmodule ElixirPlusReddit.API.Comment do
+  @moduledoc """
+  An interface for getting comment information.
+  """
+
+  alias ElixirPlusReddit.RequestBuilder
+  alias ElixirPlusReddit.RequestQueue
+  alias ElixirPlusReddit.Paginator
+  alias ElixirPlusReddit.Scheduler
+
+  @comment __MODULE__
+  @comment_base "https://oauth.reddit.com/comments"
+  @default_priority 0
+
+  @doc """
+  Get an article's `new` comments.
+
+  ### Parameters
+
+  * `from`:     The pid or name of the requester.
+  * `tag`:      Anything.
+  * `article_id:` An article id.
+  * `options`:  The query. (Optional)
+  * `priority`: The request's priority. (Optional)
+
+  ### Options
+
+  * `limit`:  a value between 1-100
+  * `after`:  a fullname of a thing
+  * `before`: a fullname of a thing
+
+  ### Fields
+
+      after
+      before
+      modhash
+      children:
+          author_flair_css_class
+          gilded
+          body_html
+          quarantine
+          report_reasons
+          stickied
+          created
+          score
+          user_reports
+          over_18
+          controversiality
+          link_id
+          edited
+          downs
+          mod_reports
+          author_flair_text
+          created_utc
+          parent_id
+          body
+          likes
+          ups
+          distinguished
+          link_author
+          removal_reason
+          replies
+          name
+          archived
+          link_title
+          subreddit
+          author
+          subreddit_id
+          saved
+          num_reports
+          id
+          score_hidden
+          approved_by
+          link_url
+          banned_by
+  """
+
+  def new_comments(from, tag, article_id) do
+    listing(from, tag, article_id, [sort: :new], @default_priority)
+  end
+
+  def new_comments(from, tag, article_id, options, priority) do
+    options = Keyword.put(options, :sort, :new)
+    listing(from, tag, article_id, options, priority)
+  end
+
+  def new_comments(from, tag, article_id, options) when is_list(options) do
+    options = Keyword.put(options, :sort, :new)
+    listing(from, tag, article_id, options, @default_priority)
+  end
+
+  def new_comments(from, tag, article_id, priority) do
+    listing(from, tag, article_id, [sort: :new], priority)
+  end
+
+  defp listing(from, tag, article_id, options, priority) do
+    url = "#{@comment_base}/#{article_id}"
+    request_data = RequestBuilder.format_get(from, tag, url, options, :listing, priority)
+    RequestQueue.enqueue_request(request_data)
+  end
+end

--- a/lib/elixirplusreddit/parser.ex
+++ b/lib/elixirplusreddit/parser.ex
@@ -21,12 +21,25 @@ defmodule ElixirPlusReddit.Parser do
     Enum.map(resp.data.trophies, fn(trophy) -> trophy.data end)
   end
 
+  def parse(resp, :listing) when is_list(resp) do
+    for r <- resp, do: parse(r, :listing)
+  end
+
   def parse(resp, :listing) do
-    Map.update!(resp.data, :children, fn(children) ->
-      Enum.map(children, fn(child) ->
-        child.data
+    parse_data(resp)
+  end
+
+  defp parse_data(resp) do
+    # Recursively flatten the data member of any children
+    if Map.has_key?(resp, :data) && Map.has_key?(resp.data, :children) do
+      Map.update!(resp.data, :children, fn(children) ->
+        Enum.map(children, fn(child) ->
+          parse_data(child.data)
+        end)
       end)
-    end)
+    else
+      resp
+    end
   end
 
   def parse(resp, :reply) do


### PR DESCRIPTION
The existing API modules didn't seem suited to my use case - getting an article's comments, and getting a specific comment thread (e.g. to check for replies by a specific user) - so I added the `Comment` module.

This first pass is a little rough. I feel like the result data is heavily nested, and could probably be altered before being returned.
